### PR TITLE
Upgrade to winapi 0.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app_dirs2"
-version = "2.0.3"
+version = "2.0.4"
 authors = ["Andy Barron <AndrewLBarron@gmail.com>", "Simon Heath <icefoxen@gmail.com>"]
 
 description = "Put your app's data in the right place on every platform -- maintained fork."
@@ -14,6 +14,4 @@ license = "MIT"
 xdg = "^2.0.0"
 
 [target.'cfg(windows)'.dependencies]
-ole32-sys = "^0.2.0"
-shell32-sys = "^0.1.1"
-winapi = "^0.2.8"
+winapi = { version = "0.3.8", features = ["shlobj", "combaseapi"] }

--- a/src/imp/platform/windows.rs
+++ b/src/imp/platform/windows.rs
@@ -14,13 +14,13 @@
 //
 // Credit for the above code goes to Connorcpu (https://github.com/Connorcpu).
 
-extern crate ole32;
-extern crate shell32;
 extern crate winapi;
 use AppDataType::*;
 use common::*;
-use self::shell32::SHGetKnownFolderPath;
-use self::winapi::{GUID, PWSTR};
+use self::winapi::shared::guiddef::GUID;
+use self::winapi::um::combaseapi::CoTaskMemFree;
+use self::winapi::um::shlobj::SHGetKnownFolderPath;
+use self::winapi::um::winnt::PWSTR;
 use std::ffi::OsString;
 use std::os::windows::ffi::OsStringExt;
 use std::path::PathBuf;
@@ -71,7 +71,7 @@ static FOLDERID_ProgramData: GUID = GUID {
 struct SafePwstr(PWSTR);
 impl Drop for SafePwstr {
     fn drop(&mut self) {
-        unsafe { ole32::CoTaskMemFree(self.0 as *mut _) }
+        unsafe { CoTaskMemFree(self.0 as *mut _) }
     }
 }
 


### PR DESCRIPTION
This is the same change as this PR on the original repo: https://github.com/AndyBarron/app-dirs-rs/pull/32.

Having this fork use the latest version of `winapi` instead of the old slow (to compile) 0.2 version should be a good motivation for more to switch over to this. And we at Embark will as well.