### PR TITLE
Android support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,5 +13,9 @@ license = "MIT"
 [target.'cfg(all(unix, not(target_os="macos")))'.dependencies]
 xdg = "^2.0.0"
 
+[target.'cfg(target_os = "android")'.dependencies]
+jni = "0.14.0"
+ndk-glue = "0.1.0"
+
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3.8", features = ["shlobj", "combaseapi"] }

--- a/src/imp/mod.rs
+++ b/src/imp/mod.rs
@@ -8,7 +8,7 @@ mod platform {
     mod macos;
     pub use self::macos::*;
 }
-#[cfg(all(unix, not(target_os="macos")))]
+#[cfg(all(unix, not(target_os="macos"), not(target_os="android")))]
 mod platform {
     mod unix;
     pub use self::unix::*;
@@ -27,6 +27,11 @@ mod platform {
 mod platform {
     mod redox;
     pub use self::redox::*;
+}
+#[cfg(target_os="android")]
+mod platform {
+    mod android;
+    pub use self::android::*;
 }
 
 /// Creates (if necessary) and returns path to **app-specific** data

--- a/src/imp/platform/android.rs
+++ b/src/imp/platform/android.rs
@@ -1,0 +1,49 @@
+use common::{AppDataType, AppDirsError};
+use std::path::PathBuf;
+use std::io::{Error, ErrorKind};
+
+pub const USE_AUTHOR: bool = false;
+
+impl From<jni::errors::Error> for AppDirsError {
+    fn from(error: jni::errors::Error) -> Self {
+        AppDirsError::Io(Error::new(ErrorKind::Other, error))
+    }
+}
+
+fn get_jni_app_dir(
+    activity: &jni::objects::JObject<'_>,
+    env: &jni::JNIEnv<'_>,
+    method: &str,
+) -> Result<String, AppDirsError> {
+
+    let dir = env.call_method(*activity, method, "()Ljava/io/File;", &Vec::new()[..])?;
+    let dir = match dir {
+        jni::objects::JValue::Object(o) => o,
+        _ => return Err(AppDirsError::Io(Error::new(ErrorKind::Other, "dir is not a object"))),
+    };
+
+    let path_string = env.call_method(dir, "getPath", "()Ljava/lang/String;", &Vec::new()[..])?;
+    let path_string = match path_string {
+        jni::objects::JValue::Object(o) => jni::objects::JString::from(o),
+        _ => return Err(AppDirsError::Io(Error::new(ErrorKind::Other, "path_string is not a object"))),
+    };
+
+    Ok(env.get_string(path_string)?.into())
+}
+
+pub fn get_app_dir(t: AppDataType) -> Result<PathBuf, AppDirsError> {
+    let native_activity = ndk_glue::native_activity();
+    let vm = unsafe { jni::JavaVM::from_raw(native_activity.vm()) }?;
+    let env = vm.attach_current_thread()?;
+    let activity = jni::objects::JObject::from(native_activity.activity());
+
+    let path_string = match t {
+        AppDataType::UserConfig => get_jni_app_dir(&activity, &env, "getDataDir")?,
+        AppDataType::UserData => get_jni_app_dir(&activity, &env, "getFilesDir")?,
+        AppDataType::UserCache => get_jni_app_dir(&activity, &env, "getCacheDir")?,
+        AppDataType::SharedData => get_jni_app_dir(&activity, &env, "getExternalFilesDir")?,
+        AppDataType::SharedConfig => get_jni_app_dir(&activity, &env, "getExternalFilesDir")?,
+    };
+
+    Ok(PathBuf::from(path_string))
+}

--- a/src/imp/platform/android.rs
+++ b/src/imp/platform/android.rs
@@ -2,8 +2,6 @@ use common::{AppDataType, AppDirsError};
 use std::path::PathBuf;
 use std::io::{Error, ErrorKind};
 
-pub const USE_AUTHOR: bool = false;
-
 impl From<jni::errors::Error> for AppDirsError {
     fn from(error: jni::errors::Error) -> Self {
         AppDirsError::Io(Error::new(ErrorKind::Other, error))

--- a/src/imp/platform/android.rs
+++ b/src/imp/platform/android.rs
@@ -41,8 +41,8 @@ pub fn get_app_dir(t: AppDataType) -> Result<PathBuf, AppDirsError> {
         AppDataType::UserConfig => get_jni_app_dir(&activity, &env, "getDataDir")?,
         AppDataType::UserData => get_jni_app_dir(&activity, &env, "getFilesDir")?,
         AppDataType::UserCache => get_jni_app_dir(&activity, &env, "getCacheDir")?,
-        AppDataType::SharedData => get_jni_app_dir(&activity, &env, "getExternalFilesDir")?,
-        AppDataType::SharedConfig => get_jni_app_dir(&activity, &env, "getExternalFilesDir")?,
+        AppDataType::SharedData => get_jni_app_dir(&activity, &env, "getExternalFilesDir")?, // Deprecated in Android 11+
+        AppDataType::SharedConfig => get_jni_app_dir(&activity, &env, "getExternalFilesDir")?, // Deprecated in Android 11+
     };
 
     Ok(PathBuf::from(path_string))


### PR DESCRIPTION
Tested on Samsung S10 Light.

There is no shared config directory so I'm using `getExternalFilesDir` instead there as well.

Note that according to the resident android expert; shared (external) storage will be deprecated in Android 11 (and 10 with exceptions).

fixes #3 