### PR TITLE
Android: Re-added `USE_AUTHOR`

### DIFF
--- a/src/imp/platform/android.rs
+++ b/src/imp/platform/android.rs
@@ -2,6 +2,8 @@ use common::{AppDataType, AppDirsError};
 use std::path::PathBuf;
 use std::io::{Error, ErrorKind};
 
+pub const USE_AUTHOR: bool = false;
+
 impl From<jni::errors::Error> for AppDirsError {
     fn from(error: jni::errors::Error) -> Self {
         AppDirsError::Io(Error::new(ErrorKind::Other, error))


### PR DESCRIPTION
This variable was not unused. See https://github.com/app-dirs-rs/app_dirs2/blob/master/src/imp/mod.rs#L100
It doesn't compile without that variable.

If you merge this could you also publish a new patch version :)?