### PR TITLE
Add support for multiple data directories

### DIFF
--- a/src/imp/mod.rs
+++ b/src/imp/mod.rs
@@ -43,6 +43,9 @@ mod platform {
 /// If the directory structure does not exist, this function will recursively
 /// create the full hierarchy. Therefore, a result of `Ok` guarantees that the
 /// returned path exists.
+///
+/// If there are multiple possible app dis, this functions picks the first one (see
+/// [`get_app_dirs.get_app_dirs.html)).
 pub fn app_dir(t: AppDataType, app: &AppInfo, path: &str) -> Result<PathBuf, AppDirsError> {
     let path = get_app_dir(t, app, &path)?;
     match fs::create_dir_all(&path) {
@@ -60,16 +63,33 @@ pub fn app_dir(t: AppDataType, app: &AppInfo, path: &str) -> Result<PathBuf, App
 /// A result of `Ok` means that we determined where the data SHOULD go, but
 /// it DOES NOT guarantee that the directory actually exists. (See
 /// [`app_dir`](fn.app_dir.html).)
+///
+/// If there are multiple possible app dis, this functions picks the first one (see
+/// [`get_app_dirs.get_app_dirs.html)).
 pub fn get_app_dir(t: AppDataType, app: &AppInfo, path: &str) -> Result<PathBuf, AppDirsError> {
-    if app.author.len() == 0 || app.name.len() == 0 {
-        return Err(AppDirsError::InvalidAppInfo);
-    }
-    get_app_root(t, app).map(|mut root| {
+    get_app_dirs(t, app, path).map(|mut v| v.remove(0))
+}
+
+
+/// Returns (but **does not create**) the paths to all possible **app-specific** data
+/// **subdirectories** for the provided data type and subdirectory path.
+///
+/// The `path` parameter should be a valid relative path separated by
+/// **forward slashes** (`/`).
+///
+/// The returned vector contains at least one element.  On some platforms, for example on Unix
+/// platforms, it may contain multiple elements.
+///
+/// A result of `Ok` means that we determined where the data SHOULD go, but
+/// it DOES NOT guarantee that the directory actually exists. (See
+/// [`app_dir`](fn.app_dir.html).)
+pub fn get_app_dirs(t: AppDataType, app: &AppInfo, path: &str) -> Result<Vec<PathBuf>, AppDirsError> {
+    get_app_roots(t, app).map(|v| v.into_iter().map(|mut root| {
         for component in path.split("/").filter(|s| s.len() > 0) {
             root.push(utils::sanitized(component));
         }
         root
-    })
+    }).collect())
 }
 
 /// Creates (if necessary) and returns path to **app-specific** data
@@ -78,6 +98,9 @@ pub fn get_app_dir(t: AppDataType, app: &AppInfo, path: &str) -> Result<PathBuf,
 /// If the directory structure does not exist, this function will recursively
 /// create the full hierarchy. Therefore, a result of `Ok` guarantees that the
 /// returned path exists.
+///
+/// If there are multiple possible app roots, this functions picks the first one (see
+/// [`get_app_roots`](fn.get_app_roots.html)).
 pub fn app_root(t: AppDataType, app: &AppInfo) -> Result<PathBuf, AppDirsError> {
     let path = get_app_root(t, app)?;
     match fs::create_dir_all(&path) {
@@ -92,17 +115,33 @@ pub fn app_root(t: AppDataType, app: &AppInfo) -> Result<PathBuf, AppDirsError> 
 /// A result of `Ok` means that we determined where the data SHOULD go, but
 /// it DOES NOT guarantee that the directory actually exists. (See
 /// [`app_root`](fn.app_root.html).)
+///
+/// If there are multiple possible app roots, this functions picks the first one (see
+/// [`get_app_roots`](fn.get_app_roots.html)).
 pub fn get_app_root(t: AppDataType, app: &AppInfo) -> Result<PathBuf, AppDirsError> {
+    get_app_roots(t, app).map(|mut v| v.remove(0))
+}
+
+/// Returns (but **does not create**) the paths of all possible **app-specific** data directories
+/// for the provided data type.
+///
+/// The returned vector contains at least one element.  On some platforms, for example on Unix
+/// platforms, it may contain multiple elements.
+///
+/// A result of `Ok` means that we determined where the data SHOULD go, but
+/// it DOES NOT guarantee that the directory actually exists. (See
+/// [`app_root`](fn.app_root.html).)
+pub fn get_app_roots(t: AppDataType, app: &AppInfo) -> Result<Vec<PathBuf>, AppDirsError> {
     if app.author.len() == 0 || app.name.len() == 0 {
         return Err(AppDirsError::InvalidAppInfo);
     }
-    get_data_root(t).map(|mut root| {
+    get_data_roots(t).map(|v| v.into_iter().map(|mut root| {
         if platform::USE_AUTHOR {
             root.push(utils::sanitized(app.author));
         }
         root.push(utils::sanitized(app.name));
         root
-    })
+    }).collect())
 }
 
 /// Creates (if necessary) and returns path to **top-level** data directory
@@ -111,6 +150,9 @@ pub fn get_app_root(t: AppDataType, app: &AppInfo) -> Result<PathBuf, AppDirsErr
 /// If the directory structure does not exist, this function will recursively
 /// create the full hierarchy. Therefore, a result of `Ok` guarantees that the
 /// returned path exists.
+///
+/// If there are multiple possible data roots, this functions picks the first one (see
+/// [`get_data_roots`](fn.get_data_roots.html)).
 pub fn data_root(t: AppDataType) -> Result<PathBuf, AppDirsError> {
     let path = get_data_root(t)?;
     match fs::create_dir_all(&path) {
@@ -125,11 +167,27 @@ pub fn data_root(t: AppDataType) -> Result<PathBuf, AppDirsError> {
 /// A result of `Ok` means that we determined where the data SHOULD go, but
 /// it DOES NOT guarantee that the directory actually exists. (See
 /// [`data_root`](fn.data_root.html).)
+///
+/// If there are multiple possible data roots, this functions picks the first one (see
+/// [`get_data_roots`](fn.get_data_roots.html)).
 pub fn get_data_root(t: AppDataType) -> Result<PathBuf, AppDirsError> {
-    let mut dirs = platform::get_app_dirs(t)?;
+    get_data_roots(t).map(|mut v| v.remove(0))
+}
+
+/// Returns (but **does not create**) the paths of all possible **top-level** data directories for
+/// the provided data type.
+///
+/// The returned vector contains at least one element.  On some platforms, for example on Unix
+/// platforms, it may contain multiple elements.
+///
+/// A result of `Ok` means that we determined where the data SHOULD go, but
+/// it DOES NOT guarantee that the directory actually exists. (See
+/// [`data_root`](fn.data_root.html).)
+pub fn get_data_roots(t: AppDataType) -> Result<Vec<PathBuf>, AppDirsError> {
+    let dirs = platform::get_app_dirs(t)?;
     if dirs.is_empty() {
         Err(AppDirsError::NotSupported)
     } else {
-        Ok(dirs.remove(0))
+        Ok(dirs)
     }
 }

--- a/src/imp/mod.rs
+++ b/src/imp/mod.rs
@@ -112,7 +112,7 @@ pub fn get_app_root(t: AppDataType, app: &AppInfo) -> Result<PathBuf, AppDirsErr
 /// create the full hierarchy. Therefore, a result of `Ok` guarantees that the
 /// returned path exists.
 pub fn data_root(t: AppDataType) -> Result<PathBuf, AppDirsError> {
-    let path = platform::get_app_dir(t)?;
+    let path = get_data_root(t)?;
     match fs::create_dir_all(&path) {
         Ok(..) => Ok(path),
         Err(e) => Err(e.into()),
@@ -126,5 +126,10 @@ pub fn data_root(t: AppDataType) -> Result<PathBuf, AppDirsError> {
 /// it DOES NOT guarantee that the directory actually exists. (See
 /// [`data_root`](fn.data_root.html).)
 pub fn get_data_root(t: AppDataType) -> Result<PathBuf, AppDirsError> {
-    platform::get_app_dir(t)
+    let mut dirs = platform::get_app_dirs(t)?;
+    if dirs.is_empty() {
+        Err(AppDirsError::NotSupported)
+    } else {
+        Ok(dirs.remove(0))
+    }
 }

--- a/src/imp/platform/android.rs
+++ b/src/imp/platform/android.rs
@@ -31,7 +31,7 @@ fn get_jni_app_dir(
     Ok(env.get_string(path_string)?.into())
 }
 
-pub fn get_app_dir(t: AppDataType) -> Result<PathBuf, AppDirsError> {
+pub fn get_app_dirs(t: AppDataType) -> Result<Vec<PathBuf>, AppDirsError> {
     let native_activity = ndk_glue::native_activity();
     let vm = unsafe { jni::JavaVM::from_raw(native_activity.vm()) }?;
     let env = vm.attach_current_thread()?;
@@ -45,5 +45,5 @@ pub fn get_app_dir(t: AppDataType) -> Result<PathBuf, AppDirsError> {
         AppDataType::SharedConfig => get_jni_app_dir(&activity, &env, "getExternalFilesDir")?, // Deprecated in Android 11+
     };
 
-    Ok(PathBuf::from(path_string))
+    Ok(vec![PathBuf::from(path_string)])
 }

--- a/src/imp/platform/macos.rs
+++ b/src/imp/platform/macos.rs
@@ -5,7 +5,7 @@ use std::path::{Component, Path, PathBuf};
 pub const USE_AUTHOR: bool = false;
 
 #[allow(deprecated)] // it's fine on macOS
-pub fn get_app_dir(t: AppDataType) -> Result<PathBuf, AppDirsError> {
+pub fn get_app_dirs(t: AppDataType) -> Result<Vec<PathBuf>, AppDirsError> {
     let dir_base: Result<PathBuf, AppDirsError> = if t.is_shared() {
         Ok(Path::new(&Component::RootDir).into())
     } else {
@@ -22,6 +22,6 @@ pub fn get_app_dir(t: AppDataType) -> Result<PathBuf, AppDirsError> {
                 path.push("Caches");
             },
         };
-        path
+        vec![path]
     })
 }

--- a/src/imp/platform/redox.rs
+++ b/src/imp/platform/redox.rs
@@ -5,7 +5,7 @@ use std::path::{Component, PathBuf};
 
 pub const USE_AUTHOR: bool = false;
 
-pub fn get_app_dir(t: AppDataType) -> Result<PathBuf, AppDirsError> {
+pub fn get_app_dirs(t: AppDataType) -> Result<Vec<PathBuf>, AppDirsError> {
     let dir_base: Result<PathBuf, AppDirsError> = if t.is_shared() {
         Ok(Component::RootDir.as_ref().into())
     } else {
@@ -29,6 +29,6 @@ pub fn get_app_dir(t: AppDataType) -> Result<PathBuf, AppDirsError> {
                 path.push("share");
             }
         };
-        path
+        vec![path]
     })
 }

--- a/src/imp/platform/unknown.rs
+++ b/src/imp/platform/unknown.rs
@@ -4,6 +4,6 @@ use std::path::PathBuf;
 
 pub const USE_AUTHOR: bool = false;
 
-pub fn get_app_dir(_t: AppDataType) -> Result<PathBuf, AppDirsError> {
+pub fn get_app_dirs(_t: AppDataType) -> Result<Vec<PathBuf>, AppDirsError> {
     Err(AppDirsError::NotSupported)
 }

--- a/src/imp/platform/windows.rs
+++ b/src/imp/platform/windows.rs
@@ -29,13 +29,13 @@ use std::slice;
 
 pub const USE_AUTHOR: bool = true;
 
-pub fn get_app_dir(t: AppDataType) -> Result<PathBuf, AppDirsError> {
+pub fn get_app_dirs(t: AppDataType) -> Result<Vec<PathBuf>, AppDirsError> {
     let folder_id = match t {
         UserConfig => &FOLDERID_RoamingAppData,
         SharedConfig | SharedData => &FOLDERID_ProgramData,
         UserCache | UserData => &FOLDERID_LocalAppData,
     };
-    get_folder_path(folder_id).map(|os_str| os_str.into())
+    get_folder_path(folder_id).map(|os_str| vec![os_str.into()])
 }
 
 /// https://msdn.microsoft.com/en-us/library/dd378457.aspx#FOLDERID_RoamingAppData

--- a/tests/unix.rs
+++ b/tests/unix.rs
@@ -2,6 +2,7 @@
 
 use std::env;
 use std::ffi;
+use std::fs;
 use std::path;
 use std::sync;
 
@@ -110,4 +111,134 @@ fn test_home_and_xdg_dirs(ty: AppDataType, env_var: impl AsRef<ffi::OsStr>) {
     let subdir = "testdir";
     let app_dir = app_dirs2::get_app_dir(ty, &app_info, subdir).unwrap();
     assert_eq!(app_root.join(subdir), app_dir);
+}
+
+#[test_case(AppDataType::UserCache, "XDG_CACHE_HOME"; "user cache")]
+#[test_case(AppDataType::UserConfig, "XDG_CONFIG_HOME"; "user config")]
+#[test_case(AppDataType::UserData, "XDG_DATA_HOME"; "user data")]
+fn test_multi_dir_user(ty: AppDataType, env_var: impl AsRef<ffi::OsStr>) {
+    let _env_guard = ENV_MUTEX.lock();
+
+    let home_dir = tempfile::tempdir().unwrap();
+    let xdg_dir = tempfile::tempdir().unwrap();
+    reset_env();
+    env::set_var("HOME", home_dir.path());
+    env::set_var(env_var.as_ref(), join_os_str(&[xdg_dir.path(), "test".as_ref()], ":"));
+
+    let data_root = app_dirs2::get_data_root(ty).unwrap();
+    let data_roots = app_dirs2::get_data_roots(ty).unwrap();
+    assert_eq!(vec![data_root], data_roots);
+
+    let app_info = app_dirs2::AppInfo {
+        name: "app-name",
+        author: "app-author",
+    };
+
+    let app_root = app_dirs2::get_app_root(ty, &app_info).unwrap();
+    let app_roots = app_dirs2::get_app_roots(ty, &app_info).unwrap();
+    assert_eq!(vec![app_root], app_roots);
+
+    let subdir = "testdir";
+    let app_dir = app_dirs2::get_app_dir(ty, &app_info, subdir).unwrap();
+    let app_dirs = app_dirs2::get_app_dirs(ty, &app_info, subdir).unwrap();
+    assert_eq!(vec![app_dir], app_dirs);
+}
+
+#[test_case(AppDataType::SharedConfig, "XDG_CONFIG_DIRS"; "shared config")]
+#[test_case(AppDataType::SharedData, "XDG_DATA_DIRS"; "shared data")]
+fn test_multi_dir_missing(ty: AppDataType, env_var: impl AsRef<ffi::OsStr>) {
+    let _env_guard = ENV_MUTEX.lock();
+
+    let root_dir = tempfile::tempdir().unwrap();
+    let dir1 = root_dir.path().join("dir1");
+    let dir2 = root_dir.path().join("dir2");
+    reset_env();
+    env::set_var(env_var.as_ref(), join_os_str(&[&dir1, &dir2], ":"));
+
+    let data_roots = app_dirs2::get_data_roots(ty).unwrap();
+    assert_eq!(vec![dir1.clone(), dir2.clone()], data_roots);
+
+    let app_info = app_dirs2::AppInfo {
+        name: "app-name",
+        author: "app-author",
+    };
+
+    let app_roots = app_dirs2::get_app_roots(ty, &app_info).unwrap();
+    assert_eq!(data_roots.iter().map(|path| path.join(app_info.name)).collect::<Vec<_>>(), app_roots);
+
+    let subdir = "testdir";
+    let app_dirs = app_dirs2::get_app_dirs(ty, &app_info, subdir).unwrap();
+    assert_eq!(app_roots.iter().map(|path| path.join(subdir)).collect::<Vec<_>>(), app_dirs);
+}
+
+#[test_case(AppDataType::SharedConfig, "XDG_CONFIG_DIRS"; "shared config")]
+#[test_case(AppDataType::SharedData, "XDG_DATA_DIRS"; "shared data")]
+fn test_multi_dir_existing_app_root(ty: AppDataType, env_var: impl AsRef<ffi::OsStr>) {
+    let _env_guard = ENV_MUTEX.lock();
+
+    let root_dir = tempfile::tempdir().unwrap();
+    let dir1 = root_dir.path().join("dir1");
+    let dir2 = root_dir.path().join("dir2");
+    fs::create_dir_all(&dir2.join("app-name")).unwrap();
+    reset_env();
+    env::set_var(env_var.as_ref(), join_os_str(&[&dir1, &dir2], ":"));
+
+    let data_roots = app_dirs2::get_data_roots(ty).unwrap();
+    assert_eq!(vec![dir2.clone()], data_roots);
+
+    let app_info = app_dirs2::AppInfo {
+        name: "app-name",
+        author: "app-author",
+    };
+
+    let app_roots = app_dirs2::get_app_roots(ty, &app_info).unwrap();
+    assert_eq!(vec![dir2.join(app_info.name)], app_roots);
+
+    let subdir = "testdir";
+    let app_dirs = app_dirs2::get_app_dirs(ty, &app_info, subdir).unwrap();
+    assert_eq!(vec![dir2.join(app_info.name).join(subdir)], app_dirs);
+}
+
+#[test_case(AppDataType::SharedConfig, "XDG_CONFIG_DIRS"; "shared config")]
+#[test_case(AppDataType::SharedData, "XDG_DATA_DIRS"; "shared data")]
+fn test_multi_dir_existing_app_dir(ty: AppDataType, env_var: impl AsRef<ffi::OsStr>) {
+    let _env_guard = ENV_MUTEX.lock();
+
+    let root_dir = tempfile::tempdir().unwrap();
+    let dir1 = root_dir.path().join("dir1");
+    let dir2 = root_dir.path().join("dir2");
+    fs::create_dir_all(&dir1.join("app-name").join("testdir")).unwrap();
+    fs::create_dir_all(&dir2.join("app-name")).unwrap();
+    reset_env();
+    env::set_var(env_var.as_ref(), join_os_str(&[&dir1, &dir2], ":"));
+
+    let data_roots = app_dirs2::get_data_roots(ty).unwrap();
+    assert_eq!(vec![dir1.clone(), dir2.clone()], data_roots);
+
+    let app_info = app_dirs2::AppInfo {
+        name: "app-name",
+        author: "app-author",
+    };
+
+    let app_roots = app_dirs2::get_app_roots(ty, &app_info).unwrap();
+    assert_eq!(data_roots.iter().map(|path| path.join(app_info.name)).collect::<Vec<_>>(), app_roots);
+
+    let subdir = "testdir";
+    let app_dirs = app_dirs2::get_app_dirs(ty, &app_info, subdir).unwrap();
+    assert_eq!(vec![dir1.join(app_info.name).join(subdir)], app_dirs);
+}
+
+fn join_os_str(
+    parts: &[impl AsRef<ffi::OsStr>],
+    separator: impl AsRef<ffi::OsStr>,
+) -> ffi::OsString {
+    let mut s = ffi::OsString::new();
+    if let Some(last) = parts.last() {
+        for part in &parts[..parts.len() - 1] {
+            s.push(part.as_ref());
+            s.push(separator.as_ref());
+        }
+        s.push(last.as_ref());
+    }
+    s
 }


### PR DESCRIPTION
This patch adds support for returning multiple app and data directories and changes the Unix implementation to use this new option for the shared data and config directories.  For all other platforms and data types, the behavior does not change.  Fixes #9.

Note that I had to modify all implementations, but I could only build and verify the Unix implementation.