### PR TITLE
Bump Android dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,8 @@ edition = "2018"
 xdg = "^2.0.0"
 
 [target.'cfg(target_os = "android")'.dependencies]
-jni = "0.14.0"
-ndk-glue = "0.1.0"
+jni = "0.18.0"
+ndk-glue = "0.2.0"
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3.8", features = ["shlobj", "combaseapi"] }


### PR DESCRIPTION
- Bumps `jni` to 0.18.0 
- Bumps `ndk-glue` to 0.2.0

