### PR TITLE
android: Migrate from `ndk-glue` to `ndk-context`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ xdg = "^2.0.0"
 
 [target.'cfg(target_os = "android")'.dependencies]
 jni = "0.19.0"
-ndk-glue = "0.6.0"
+ndk-context = "0.1.0"
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3.8", features = ["shlobj", "combaseapi"] }

--- a/src/imp/platform/android.rs
+++ b/src/imp/platform/android.rs
@@ -1,6 +1,6 @@
 use crate::common::*;
-use std::path::PathBuf;
 use std::io::{Error, ErrorKind};
+use std::path::PathBuf;
 
 pub const USE_AUTHOR: bool = false;
 
@@ -11,38 +11,47 @@ impl From<jni::errors::Error> for AppDirsError {
 }
 
 fn get_jni_app_dir(
-    activity: &jni::objects::JObject<'_>,
+    context: &jni::objects::JObject<'_>,
     env: &jni::JNIEnv<'_>,
     method: &str,
 ) -> Result<String, AppDirsError> {
-
-    let dir = env.call_method(*activity, method, "()Ljava/io/File;", &Vec::new()[..])?;
+    let dir = env.call_method(*context, method, "()Ljava/io/File;", &Vec::new()[..])?;
     let dir = match dir {
         jni::objects::JValue::Object(o) => o,
-        _ => return Err(AppDirsError::Io(Error::new(ErrorKind::Other, "dir is not a object"))),
+        _ => {
+            return Err(AppDirsError::Io(Error::new(
+                ErrorKind::Other,
+                "dir is not `JObject`",
+            )))
+        },
     };
 
     let path_string = env.call_method(dir, "getPath", "()Ljava/lang/String;", &Vec::new()[..])?;
     let path_string = match path_string {
         jni::objects::JValue::Object(o) => jni::objects::JString::from(o),
-        _ => return Err(AppDirsError::Io(Error::new(ErrorKind::Other, "path_string is not a object"))),
+        _ => {
+            return Err(AppDirsError::Io(Error::new(
+                ErrorKind::Other,
+                "path_string is not `JObject`",
+            )))
+        },
     };
 
     Ok(env.get_string(path_string)?.into())
 }
 
 pub fn get_app_dir(t: AppDataType) -> Result<PathBuf, AppDirsError> {
-    let native_activity = ndk_glue::native_activity();
-    let vm = unsafe { jni::JavaVM::from_raw(native_activity.vm()) }?;
+    let android_context = ndk_context::android_context();
+    let vm = unsafe { jni::JavaVM::from_raw(android_context.vm().cast()) }?;
     let env = vm.attach_current_thread()?;
-    let activity = jni::objects::JObject::from(native_activity.activity());
+    let context = jni::objects::JObject::from(android_context.context().cast());
 
     let path_string = match t {
-        AppDataType::UserConfig => get_jni_app_dir(&activity, &env, "getDataDir")?,
-        AppDataType::UserData => get_jni_app_dir(&activity, &env, "getFilesDir")?,
-        AppDataType::UserCache => get_jni_app_dir(&activity, &env, "getCacheDir")?,
-        AppDataType::SharedData => get_jni_app_dir(&activity, &env, "getExternalFilesDir")?, // Deprecated in Android 11+
-        AppDataType::SharedConfig => get_jni_app_dir(&activity, &env, "getExternalFilesDir")?, // Deprecated in Android 11+
+        AppDataType::UserConfig => get_jni_app_dir(&context, &env, "getDataDir")?,
+        AppDataType::UserData => get_jni_app_dir(&context, &env, "getFilesDir")?,
+        AppDataType::UserCache => get_jni_app_dir(&context, &env, "getCacheDir")?,
+        AppDataType::SharedData => get_jni_app_dir(&context, &env, "getExternalFilesDir")?, // Deprecated in Android 11+
+        AppDataType::SharedConfig => get_jni_app_dir(&context, &env, "getExternalFilesDir")?, // Deprecated in Android 11+
     };
 
     Ok(PathBuf::from(path_string))


### PR DESCRIPTION
`ndk-glue` suffers one fatal flaw: it's "only" supposed to be used by the crate providing `fn main()` and only supposed to end up in the dependency graph once as it has `static` globals which get duplicated across versions.

In the current case with `winit 0.26` still on `ndk-glue 0.5` but `app_dirs2` booted from `0.4` to `0.6` it'll always panic in `fn native_activity()` as the `static` globals on these versions are not initialized: https://github.com/app-dirs-rs/app_dirs2/pull/18#issuecomment-1029026065

Introducing `ndk-context`: a crate that holds these `static`s, with the intention/premise to not see a breaking release /ever/ and make this a problem of the past.  The crate is currently initialized with the VM and Android Context on `ndk-glue` 0.5.1 and 0.6.1 making it compatible with whatever is current, and the possibility for backporting to older `ndk-glue` versions too.

See also:
https://github.com/rust-windowing/android-ndk-rs/issues/211
https://github.com/rust-windowing/android-ndk-rs/pull/223
