### PR TITLE
Add a test-example that runs on Android

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,5 +27,13 @@ lazy_static = "1.4"
 tempfile = "3"
 test-case = "1"
 
+[target.'cfg(target_os = "android")'.dev-dependencies]
+ndk-glue = { version = "0.6", features = ["logger"] }
+log = "0.4"
+
 [badges]
 maintenance = { status = "passively-maintained" }
+
+[[example]]
+name = "android"
+crate-type = ["cdylib"]

--- a/examples/android.rs
+++ b/examples/android.rs
@@ -1,0 +1,24 @@
+use app_dirs2::*;
+use log::info;
+
+const NDK_APP_INFO: AppInfo = AppInfo {
+    name: "unnecessary",
+    author: "The Android NDK Authors",
+};
+
+#[cfg_attr(
+    target_os = "android",
+    ndk_glue::main(backtrace = "full", logger(level = "info", tag = "app_dirs2"))
+)]
+fn main() {
+    let all = [
+        AppDataType::UserConfig,
+        AppDataType::UserData,
+        AppDataType::UserCache,
+        AppDataType::SharedConfig,
+        AppDataType::SharedData,
+    ];
+    for t in all {
+        info!("{:?}: {:?}", t, app_root(t, &NDK_APP_INFO));
+    }
+}


### PR DESCRIPTION
Depends on #20


Run with:

	cargo apk r --example android

(Requires `cargo-apk` and an Android SDK+NDK to be installed)

Outputs:

	I app_dirs2: android: UserConfig: Ok("/data/user/0/rust.example.android/unnecessary")
	I app_dirs2: android: UserData: Ok("/data/user/0/rust.example.android/files/unnecessary")
	I app_dirs2: android: UserCache: Ok("/data/user/0/rust.example.android/cache/unnecessary")
	I app_dirs2: android: SharedConfig: Ok("/storage/emulated/0/Android/data/rust.example.android/files/unnecessary")
	I app_dirs2: android: SharedData: Ok("/storage/emulated/0/Android/data/rust.example.android/files/unnecessary")
