### PR TITLE
rustfmt: Remove unknown/default options

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,4 +1,1 @@
 match_block_trailing_comma = true
-reorder_imports = true
-reorder_imported_names = true
-write_mode = "Overwrite"


### PR DESCRIPTION
`reorder_imports` is `true` by default, and `reorder_imported_names` and `write_mode` are not recognized by current rustfmt.
