### PR TITLE
Upgrade to `test-case 2` to support return types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ winapi = { version = "0.3.8", features = ["shlobj", "combaseapi"] }
 [dev-dependencies]
 lazy_static = "1.4"
 tempfile = "3"
-test-case = "1"
+test-case = "2"
 
 [target.'cfg(target_os = "android")'.dev-dependencies]
 ndk-glue = { version = "0.6", features = ["logger"] }


### PR DESCRIPTION
`tests/fs.rs` fails to compile on `test-case 1`:

    error: Test function test_no_create has a return-type but no exected clause in the test-case. This is currently unsupported. See test-case documentation for more details.
      --> tests/fs.rs:41:39
       |
    41 | fn test_no_create(ty: AppDataType) -> io::Result<()> {
       |                                       ^^
    ...
    error: could not compile `app_dirs2` due to 2 previous errors

This has been addressed in `test-case 2`, where returning a `Result` from a `test_case` function actually fails the test (and compiles sucessfully in the first place).
