### PR TITLE
examples/android: Add missing `target_os="android"` guard

### DIFF
--- a/examples/android.rs
+++ b/examples/android.rs
@@ -1,3 +1,5 @@
+#![cfg(target_os = "android")]
+
 use app_dirs2::*;
 use log::info;
 


### PR DESCRIPTION
On other platforms the `log` dependency will otherwise be missing, since this is only included in `Cargo.toml` for `"android"`.
