### PR TITLE
Add CI through GitHub actions

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -1,0 +1,80 @@
+name: Rust
+
+on: [push, pull_request]
+
+jobs:
+  formatting:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        override: true
+        profile: minimal
+        components: rustfmt
+    - name: Format
+      uses: actions-rs/cargo@v1
+      with:
+        command: fmt
+        args: --all -- --check
+
+  clippy:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        override: true
+        profile: minimal
+        components: clippy
+    - name: Clippy
+      uses: actions-rs/cargo@v1
+      with:
+        command: clippy
+        args: --all --all-targets -- -Dwarnings
+
+  test:
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+          - windows-latest
+          - macos-latest
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        override: true
+        profile: minimal
+    - name: Test all-targets
+      uses: actions-rs/cargo@v1
+      with:
+        command: test
+        args: --workspace --all-targets
+    - name: Test docs
+      uses: actions-rs/cargo@v1
+      with:
+        command: test
+        args: --workspace --doc
+
+  docs:
+    runs-on: ubuntu-latest
+    name: Build-test docs
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        override: true
+        profile: minimal
+    - name: Document all crates
+      uses: actions-rs/cargo@v1
+      env:
+        RUSTDOCFLAGS: -Dwarnings
+      with:
+        command: doc
+        args: --all --all-features --no-deps --document-private-items


### PR DESCRIPTION
An often-used crate like `app_dirs2` can't really go without automated code checking and tests: as bare minimum the code should be formatted correctly and satisfy standard clippy lints to the delight of developers and contributors, and the tests should be executed to make sure the result keeps working at all times.  Finally the documentation is build-tested to make sure that it contains no invalid links nor broken markdown.

This script is copied verbatim from my contribution at https://github.com/dvc94ch/cargo-subcommand/commit/0a53c8994af15a07283f5868127cb8fb1128d611, only ubuntu and macos are added to the test runs.

---

This PR obviously implies that all these issues are fixed, for which I opened separate PRs. Please merge those first, then I'll rebase the commits out of this one :)
