### PR TITLE
Replace ancient `lazy_static` crate with `once_cell`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ ndk-context = "0.1.0"
 winapi = { version = "0.3.8", features = ["shlobj", "combaseapi"] }
 
 [dev-dependencies]
-lazy_static = "1.4"
+once_cell = "1"
 tempfile = "3"
 test-case = "2"
 

--- a/tests/fs.rs
+++ b/tests/fs.rs
@@ -6,6 +6,7 @@ use std::path;
 use std::sync;
 
 use app_dirs2::AppDataType;
+use once_cell::sync::Lazy;
 use test_case::test_case;
 
 // This test suite checks the effects of the app_dirs2 crate on the file system.
@@ -18,10 +19,8 @@ use test_case::test_case;
 // configuration root, we have to make sure that the tests are run in sequence and don’t overlap,
 // see the `ENV_MUTEX` mutex.
 
-lazy_static::lazy_static! {
-    // For test cases that depend on environment variables
-    static ref ENV_MUTEX: sync::Mutex<()> = sync::Mutex::new(());
-}
+// For test cases that depend on environment variables
+static ENV_MUTEX: Lazy<sync::Mutex<()>> = Lazy::new(|| sync::Mutex::new(()));
 
 fn set_root_dir(path: &path::Path) -> path::PathBuf {
     let root = path.join("root");

--- a/tests/unix.rs
+++ b/tests/unix.rs
@@ -6,12 +6,11 @@ use std::path;
 use std::sync;
 
 use app_dirs2::AppDataType;
+use once_cell::sync::Lazy;
 use test_case::test_case;
 
-lazy_static::lazy_static! {
-    // For test cases that depend on environment variables
-    static ref ENV_MUTEX: sync::Mutex<()> = sync::Mutex::new(());
-}
+// For test cases that depend on environment variables
+static ENV_MUTEX: Lazy<sync::Mutex<()>> = Lazy::new(|| sync::Mutex::new(()));
 
 fn reset_env() {
     env::set_var("HOME", "");


### PR DESCRIPTION
Piggybacking on the [motivation in winit]: `lazy_static!` is a macro whereas `once_cell` achieves the same using generics.  Its implementation has also been [proposed for inclusion in `std`], making it easier to switch to a standardized version if/when that happens.  The author of that winit PR is making this change to many more crates, slowly turning the scales in favour of `once_cell` in most dependency trees (despite this being a `dev-dependency` used in tests exclusively, hence not relevant for downstream crates).  Furthermore `lazy_static` hasn't published any updates for 3 years.

See also [the `once_cell` F.A.Q.].

[motivation in winit]: https://github.com/rust-windowing/winit/pull/2313
[proposed for inclusion in `std`]: https://github.com/rust-lang/rust/issues/74465
[the `once_cell` F.A.Q.]: https://docs.rs/once_cell/latest/once_cell/#faq
