### PR TITLE
Avoid crashes on Termux in Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ## This is the up-to-date version of `app_dirs`
 
-The original [app_dirs](https://lib.rs/crates/app_dirs) crate is unmaintained and has seriously outdated dependencies. This is an fork that keeps the crate working and up-to-date.
+The original [app_dirs](https://lib.rs/crates/app_dirs) crate is unmaintained and has seriously outdated dependencies. This is a fork that keeps the crate working and up-to-date.
 
 This is a *community-maintained project*, so if you find a bug or the crate is missing support for your platform, please help out.
 
@@ -21,7 +21,7 @@ https://docs.rs/app_dirs2
 Add the following to your `Cargo.toml` under `[dependencies]`:
 
 ```toml
-app_dirs = { package = "app_dirs2", version = "2.3" }
+app_dirs = { package = "app_dirs2", version = "2.5" }
 ```
 
 The syntax with `package` allows you to keep the old name in the code (`use app_dirs::*`), so that it's a drop-in replacement.

--- a/src/imp/mod.rs
+++ b/src/imp/mod.rs
@@ -8,7 +8,12 @@ mod platform {
     mod macos;
     pub use self::macos::*;
 }
-#[cfg(all(unix, not(target_os = "macos"), not(target_os = "ios"), not(target_os = "android")))]
+#[cfg(all(
+    unix,
+    not(target_os = "macos"),
+    not(target_os = "ios"),
+    not(target_os = "android")
+))]
 mod platform {
     mod unix;
     pub use self::unix::*;
@@ -25,7 +30,10 @@ mod platform {
 }
 #[cfg(target_os = "android")]
 mod platform {
+    // As per #33, Android tries the Unix path to avoid crashes for programs run
+    // inside Termux.
     mod android;
+    mod unix;
     pub use self::android::*;
 }
 

--- a/src/imp/platform/unix.rs
+++ b/src/imp/platform/unix.rs
@@ -4,6 +4,9 @@ use crate::common::*;
 use crate::AppDataType::*;
 use std::path::PathBuf;
 
+// On Android we build this module to try XDG environment variables (#33), but
+// this constant is unused and triggers a compiler warning.
+#[cfg(not(target_os = "android"))]
 pub const USE_AUTHOR: bool = false;
 
 pub fn get_app_dir(t: AppDataType) -> Result<PathBuf, AppDirsError> {


### PR DESCRIPTION
Closes #33, using the workaround discussed in tectonic-typesetting/tectonic#926.

I'm only able to test that this compiles. Hopefully there's nothing subtle here ...

CC @MarijnS95 @dvc94ch @msiglreith @kornelski