### PR TITLE
bump test-case from v2 to v3, exclude some files from published crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ license = "MIT"
 readme = "README.md"
 repository = "https://github.com/app-dirs-rs/app_dirs2"
 edition = "2018"
+exclude = ["/appveyor.yml", "/appveyor_rust_install.ps1", "/rustfmt.toml", "/.github/", "/.travis.yml"]
 
 [target.'cfg(all(unix, not(target_os = "macos")))'.dependencies]
 xdg = "2.4.1"
@@ -25,7 +26,7 @@ winapi = { version = "0.3.9", features = ["shlobj", "combaseapi"] }
 [dev-dependencies]
 once_cell = "1.14.0"
 tempfile = "3.3.0"
-test-case = "2.2.1"
+test-case = "3"
 
 [target.'cfg(target_os = "android")'.dev-dependencies]
 ndk-glue = { version = "0.7.0", features = ["logger"] }


### PR DESCRIPTION
The update from test-case v2 to v3 does not require code changes in this crate.

I also added a `package.exclude` setting to Cargo.toml to prevent some development / CI files that are not useful for people who just use this crate as a dependency from being included in crates that are published in crates.io, which makes the download size a bit smaller (18.3 kB → 17.5 kB).
